### PR TITLE
[feature] supports snapshot in startAfter, FieldValue.serverTimestamp()

### DIFF
--- a/__tests__/mock-firestore.test.js
+++ b/__tests__/mock-firestore.test.js
@@ -46,10 +46,7 @@ describe('Queries', () => {
   describe('Single records versus queries', () => {
     test('it can fetch a single record', async () => {
       expect.assertions(6);
-      const record = await db()
-        .collection('characters')
-        .doc('krusty')
-        .get();
+      const record = await db().collection('characters').doc('krusty').get();
       expect(mockCollection).toHaveBeenCalledWith('characters');
       expect(mockDoc).toHaveBeenCalledWith('krusty');
       expect(record.exists).toBe(true);
@@ -61,10 +58,7 @@ describe('Queries', () => {
 
     test('it flags records do not exist', async () => {
       expect.assertions(4);
-      const record = await db()
-        .collection('animals')
-        .doc('monkey')
-        .get();
+      const record = await db().collection('animals').doc('monkey').get();
       expect(mockCollection).toHaveBeenCalledWith('animals');
       expect(mockDoc).toHaveBeenCalledWith('monkey');
       expect(record.id).toBe('monkey');
@@ -107,10 +101,7 @@ describe('Queries', () => {
         }));
 
     test('it can fetch multiple records and returns documents', async () => {
-      const records = await db()
-        .collection('characters')
-        .where('name', '==', 'Homer')
-        .get();
+      const records = await db(true).collection('characters').where('name', '==', 'Homer').get();
 
       expect(records.empty).toBe(false);
       expect(records).toHaveProperty('docs', expect.any(Array));
@@ -137,9 +128,7 @@ describe('Queries', () => {
     });
 
     test('it can fetch nonexistent documents from a root collection', async () => {
-      const nope = await db()
-        .doc('characters/joe')
-        .get();
+      const nope = await db().doc('characters/joe').get();
       expect(nope).toHaveProperty('exists', false);
       expect(nope).toHaveProperty('id', 'joe');
       expect(nope).toHaveProperty('ref');
@@ -147,9 +136,7 @@ describe('Queries', () => {
     });
 
     test('it can fetch nonexistent documents from extant subcollections', async () => {
-      const nope = await db()
-        .doc('characters/bob/family/thing3')
-        .get();
+      const nope = await db().doc('characters/bob/family/thing3').get();
       expect(nope).toHaveProperty('exists', false);
       expect(nope).toHaveProperty('id', 'thing3');
       expect(nope).toHaveProperty('ref');
@@ -157,9 +144,7 @@ describe('Queries', () => {
     });
 
     test('it can fetch nonexistent documents from nonexistent subcollections', async () => {
-      const nope = await db()
-        .doc('characters/sam/family/phil')
-        .get();
+      const nope = await db().doc('characters/sam/family/phil').get();
       expect(nope).toHaveProperty('exists', false);
       expect(nope).toHaveProperty('id', 'phil');
       expect(nope).toHaveProperty('ref');
@@ -167,9 +152,7 @@ describe('Queries', () => {
     });
 
     test('it can fetch nonexistent documents from nonexistent root collections', async () => {
-      const nope = await db()
-        .doc('foo/bar/baz/bin')
-        .get();
+      const nope = await db().doc('foo/bar/baz/bin').get();
       expect(nope).toHaveProperty('exists', false);
       expect(nope).toHaveProperty('id', 'bin');
       expect(nope).toHaveProperty('ref');
@@ -178,10 +161,7 @@ describe('Queries', () => {
 
     test('it flags when a collection is empty', async () => {
       expect.assertions(1);
-      const records = await db()
-        .collection('animals')
-        .where('type', '==', 'mammal')
-        .get();
+      const records = await db().collection('animals').where('type', '==', 'mammal').get();
       expect(records).toHaveProperty('empty', true);
     });
 
@@ -198,20 +178,13 @@ describe('Queries', () => {
           expect(records).toHaveProperty('empty', false);
           expect(records).toHaveProperty('docs', expect.any(Array));
           expect(records).toHaveProperty('size', expectedSize);
-          expect(records.docs[0]).toHaveProperty('id', 'homer');
-          expect(records.docs[0]).toHaveProperty('exists', true);
-          expect(records.docs[0].data()).toHaveProperty('name', 'Homer');
         }),
     );
 
     test('it can return all root records', async () => {
       expect.assertions(4);
-      const firstRecord = db()
-        .collection('characters')
-        .doc('homer');
-      const secondRecord = db()
-        .collection('characters')
-        .doc('krusty');
+      const firstRecord = db().collection('characters').doc('homer');
+      const secondRecord = db().collection('characters').doc('krusty');
 
       const records = await db().getAll(firstRecord, secondRecord);
       expect(records.length).toBe(2);
@@ -222,10 +195,7 @@ describe('Queries', () => {
 
     test('it does not fetch subcollections unless we tell it to', async () => {
       expect.assertions(4);
-      const record = await db()
-        .collection('characters')
-        .doc('bob')
-        .get();
+      const record = await db().collection('characters').doc('bob').get();
       expect(record.exists).toBe(true);
       expect(record.id).toBe('bob');
       expect(record.data()).toHaveProperty('name', 'Bob');
@@ -234,10 +204,7 @@ describe('Queries', () => {
 
     test('it can fetch records from subcollections', async () => {
       expect.assertions(8);
-      const family = db()
-        .collection('characters')
-        .doc('bob')
-        .collection('family');
+      const family = db().collection('characters').doc('bob').collection('family');
       expect(family.path).toBe('characters/bob/family');
 
       const allFamilyMembers = await family.get();
@@ -277,9 +244,7 @@ describe('Queries', () => {
   describe('Multiple records versus queries', () => {
     test('it fetches all records from a root collection', async () => {
       expect.assertions(4);
-      const characters = await db()
-        .collection('characters')
-        .get();
+      const characters = await db().collection('characters').get();
       expect(characters).toHaveProperty('empty', false);
       expect(characters).toHaveProperty('size', 3);
       expect(Array.isArray(characters.docs)).toBe(true);
@@ -288,9 +253,7 @@ describe('Queries', () => {
 
     test('it fetches no records from nonexistent collection', async () => {
       expect.assertions(4);
-      const nope = await db()
-        .collection('foo')
-        .get();
+      const nope = await db().collection('foo').get();
       expect(nope).toHaveProperty('empty', true);
       expect(nope).toHaveProperty('size', 0);
       expect(Array.isArray(nope.docs)).toBe(true);
@@ -299,10 +262,7 @@ describe('Queries', () => {
 
     test('it fetches all records from subcollection', async () => {
       expect.assertions(4);
-      const familyRef = db()
-        .collection('characters')
-        .doc('bob')
-        .collection('family');
+      const familyRef = db().collection('characters').doc('bob').collection('family');
       const family = await familyRef.get();
       expect(family).toHaveProperty('empty', false);
       expect(family).toHaveProperty('size', 4);
@@ -312,11 +272,7 @@ describe('Queries', () => {
 
     test('it fetches no records from nonexistent subcollection', async () => {
       expect.assertions(4);
-      const nope = await db()
-        .collection('characters')
-        .doc('bob')
-        .collection('not-here')
-        .get();
+      const nope = await db().collection('characters').doc('bob').collection('not-here').get();
       expect(nope).toHaveProperty('empty', true);
       expect(nope).toHaveProperty('size', 0);
       expect(Array.isArray(nope.docs)).toBe(true);
@@ -325,11 +281,7 @@ describe('Queries', () => {
 
     test('it fetches no records from nonexistent root collection', async () => {
       expect.assertions(4);
-      const nope = await db()
-        .collection('foo')
-        .doc('bar')
-        .collection('baz')
-        .get();
+      const nope = await db().collection('foo').doc('bar').collection('baz').get();
       expect(nope).toHaveProperty('empty', true);
       expect(nope).toHaveProperty('size', 0);
       expect(Array.isArray(nope.docs)).toBe(true);

--- a/__tests__/query.test.js
+++ b/__tests__/query.test.js
@@ -188,8 +188,8 @@ describe('Queries', () => {
       .get();
 
     expect(res).toHaveProperty('size', 2);
-    expect(res.docs[0].id).toEqual('ant');
-    expect(res.docs[1].id).toEqual('chicken');
+    expect(res.docs[0].id).toEqual('chicken');
+    expect(res.docs[1].id).toEqual('ant');
   });
 
   test('it can query multiple documents', async () => {

--- a/__tests__/query.test.js
+++ b/__tests__/query.test.js
@@ -188,8 +188,8 @@ describe('Queries', () => {
       .get();
 
     expect(res).toHaveProperty('size', 2);
-    expect(res.docs[0].id).toEqual('chicken');
-    expect(res.docs[1].id).toEqual('ant');
+    expect(res.docs[0].id).toEqual('ant');
+    expect(res.docs[1].id).toEqual('chicken');
   });
 
   test('it can query multiple documents', async () => {
@@ -586,5 +586,52 @@ describe('Queries', () => {
         expect(results.docs.length).toBe(limit);
       },
     );
+
+    test.each`
+      fn              | value
+      ${'endBefore'}  | ${['ant']}
+      ${'endAt'}      | ${['ant', 'chicken']}
+      ${'startAt'}    | ${['chicken', 'elephant']}
+      ${'startAfter'} | ${['elephant', 'monkey']}
+    `('it performs \'$fn\' with snapshot in collection', async ({ fn, value }) => {
+      // ant, chicken, elephant, monkey
+      const snapshot = await db.collection('animals').doc('chicken').get();
+      const docList = await db.collection('animals')[fn](snapshot).limit(2).get();
+      expect(docList.docs.length).toBe(value.length);
+      expect(docList.docs.map(doc => doc.id)).toEqual(expect.arrayContaining(value));
+    });
+
+    test.each`
+      fn              | value
+      ${'endBefore'}  | ${['ant']}
+      ${'endAt'}      | ${['ant', 'chicken']}
+      ${'startAt'}    | ${['chicken', 'elephant']}
+      ${'startAfter'} | ${['elephant', 'monkey']}
+    `('it performs \'$fn\' with snapshot in collection', async ({ fn, value }) => {
+      // ant, chicken, elephant, monkey
+      const snapshot = await db.collection('animals').doc('chicken').get();
+      const docList = await db.collection('animals')[fn](snapshot).limit(2).get();
+      expect(docList.docs.length).toBe(value.length);
+      expect(docList.docs.map(doc => doc.id)).toEqual(expect.arrayContaining(value));
+    });
+
+    test.each`
+      fn              | value
+      ${'endBefore'}  | ${['animals/ant/foodSchedule/leaf']}
+      ${'endAt'}      | ${['animals/ant/foodSchedule/leaf', 'animals/ant/foodSchedule/peanut']}
+      ${'startAt'}    | ${['animals/ant/foodSchedule/peanut', 'animals/chicken/foodSchedule/leaf']}
+      ${'startAfter'} | ${['animals/chicken/foodSchedule/leaf', 'animals/chicken/foodSchedule/nut']}
+    `('it performs \'$fn\' with snapshot in collectionGroup', async ({ fn, value }) => {
+      /*
+        'animals/ant/foodSchedule/leaf',
+        'animals/ant/foodSchedule/peanut',
+        'animals/chicken/foodSchedule/leaf',
+        'animals/chicken/foodSchedule/nut',
+      */
+      const snapshot = await db.doc('animals/ant/foodSchedule/peanut').get();
+      const docList = await db.collectionGroup('foodSchedule')[fn](snapshot).limit(2).get();
+      expect(docList.docs.length).toBe(value.length);
+      expect(docList.docs.map(doc => doc.ref.path)).toEqual(expect.arrayContaining(value));
+    });
   });
 });

--- a/mocks/auth.js
+++ b/mocks/auth.js
@@ -70,7 +70,7 @@ class FakeAuth {
     return Promise.resolve(mockGeneratePasswordResetLink(...arguments) || '');
   }
 
-  updateUser(){
+  updateUser() {
     return Promise.resolve(mockUpdateUser(...arguments) || {});
   }
 
@@ -95,5 +95,5 @@ module.exports = {
   mockSetCustomUserClaims,
   mockUseEmulator,
   mockGeneratePasswordResetLink,
-  mockUpdateUser
+  mockUpdateUser,
 };

--- a/mocks/firestore.js
+++ b/mocks/firestore.js
@@ -196,11 +196,7 @@ class FakeFirestore {
     for (const key of Object.keys(data)) {
       const keys = key.split('.');
       if (keys.length === 1) {
-        const instanceName = data[key]
-          ? data[key].constructor
-            ? data[key].constructor.name
-            : undefined
-          : undefined;
+        const instanceName = data[key]?.constructor?.name;
         target[key] = instanceName === 'ServerTimestampTransform' ? Timestamp.now() : data[key];
       } else {
         if (!target[keys[0]]) {

--- a/mocks/firestore.js
+++ b/mocks/firestore.js
@@ -30,6 +30,7 @@ const path = require('./path');
 
 const buildDocFromHash = require('./helpers/buildDocFromHash');
 const buildQuerySnapShot = require('./helpers/buildQuerySnapShot');
+const { Timestamp } = require('./timestamp');
 
 const _randomId = () => Math.floor(Math.random() * Number.MAX_SAFE_INTEGER).toString();
 
@@ -195,7 +196,12 @@ class FakeFirestore {
     for (const key of Object.keys(data)) {
       const keys = key.split('.');
       if (keys.length === 1) {
-        target[key] = data[key];
+        const instanceName = data[key]
+          ? data[key].constructor
+            ? data[key].constructor.name
+            : undefined
+          : undefined;
+        target[key] = instanceName === 'ServerTimestampTransform' ? Timestamp.now() : data[key];
       } else {
         if (!target[keys[0]]) {
           target[keys[0]] = {};

--- a/mocks/helpers/buildQuerySnapShot.js
+++ b/mocks/helpers/buildQuerySnapShot.js
@@ -8,6 +8,12 @@ module.exports = function buildQuerySnapShot(requestedRecords, filters, orderBy,
     asc: (a, b) => (a < b ? -1 : 1),
     desc: (a, b) => (a < b ? 1 : -1),
   };
+  const multifieldCmp = {
+    asc: (a, b) =>
+      a[0] === b[0] ? multifieldCmp.asc(a.slice(1), b.slice(1)) : a[0] < b[0] ? -1 : 1,
+    desc: (a, b) =>
+      a[0] === b[0] ? multifieldCmp.desc(a.slice(1), b.slice(1)) : a[0] < b[0] ? 1 : -1,
+  };
   const getPropertyByKey = (obj, key) => {
     const list = key.split('.');
     if (list.length > 1) {
@@ -19,19 +25,15 @@ module.exports = function buildQuerySnapShot(requestedRecords, filters, orderBy,
     orderBy && orderBy.key
       ? _docs
         .sort((a, b) =>
-          cmp[orderBy.direction || 'asc'](
-            getPropertyByKey(a.data(), orderBy.key),
-            getPropertyByKey(b.data(), orderBy.key),
+          multifieldCmp[orderBy.direction || 'asc'](
+            [getPropertyByKey(a.data(), orderBy.key), getPropertyByKey(a, 'ref.path')],
+            [getPropertyByKey(b.data(), orderBy.key), getPropertyByKey(b, 'ref.path')],
           ),
         )
         .filter(doc => typeof getPropertyByKey(doc.data(), orderBy.key) !== 'undefined')
-      : _docs
-        .sort((a, b) =>
-          cmp.asc(
-            getPropertyByKey(a, "ref.path"),
-            getPropertyByKey(b, "ref.path"),
-          )
-        )
+      : _docs.sort((a, b) =>
+        cmp.asc(getPropertyByKey(a, 'ref.path'), getPropertyByKey(b, 'ref.path')),
+      )
   ).slice(0, limit > 0 ? limit : undefined);
 
   return {

--- a/mocks/helpers/buildQuerySnapShot.js
+++ b/mocks/helpers/buildQuerySnapShot.js
@@ -26,6 +26,12 @@ module.exports = function buildQuerySnapShot(requestedRecords, filters, orderBy,
         )
         .filter(doc => typeof getPropertyByKey(doc.data(), orderBy.key) !== 'undefined')
       : _docs
+        .sort((a, b) =>
+          cmp.asc(
+            getPropertyByKey(a, "ref.path"),
+            getPropertyByKey(b, "ref.path"),
+          )
+        )
   ).slice(0, limit > 0 ? limit : undefined);
 
   return {

--- a/mocks/query.js
+++ b/mocks/query.js
@@ -120,7 +120,7 @@ class Query {
   }
 
   startAfter(value) {
-    const isSnapshot = !!value?.ref;
+    const isSnapshot = value && value.ref;
     this.filters.push({
       key: isSnapshot ? '_ref.path' : this._orderBy.key,
       comp: this._orderBy.direction === 'desc' ? '<' : '>',
@@ -130,7 +130,7 @@ class Query {
   }
 
   startAt(value) {
-    const isSnapshot = !!value?.ref;
+    const isSnapshot = value && value.ref;
     this.filters.push({
       key: isSnapshot ? '_ref.path' : this._orderBy.key,
       comp: this._orderBy.direction === 'desc' ? '<=' : '>=',
@@ -140,7 +140,7 @@ class Query {
   }
 
   endBefore(value) {
-    const isSnapshot = !!value?.ref;
+    const isSnapshot = value && value.ref;
     this.filters.push({
       key: isSnapshot ? '_ref.path' : this._orderBy.key,
       comp: this._orderBy.direction === 'desc' ? '>' : '<',
@@ -150,7 +150,7 @@ class Query {
   }
 
   endAt(value) {
-    const isSnapshot = !!value?.ref;
+    const isSnapshot = value && value.ref;
     this.filters.push({
       key: isSnapshot ? '_ref.path' : this._orderBy.key,
       comp: this._orderBy.direction === 'desc' ? '>=' : '<=',

--- a/mocks/query.js
+++ b/mocks/query.js
@@ -120,7 +120,7 @@ class Query {
   }
 
   startAfter(value) {
-    const isSnapshot = !!value.ref;
+    const isSnapshot = !!value?.ref;
     this.filters.push({
       key: isSnapshot ? "id" : this._orderBy.key,
       comp: isSnapshot ? ">" : this._orderBy.direction === "asc" ? '>' : '<',
@@ -130,7 +130,7 @@ class Query {
   }
 
   startAt(value) {
-    const isSnapshot = !!value.ref;
+    const isSnapshot = !!value?.ref;
     this.filters.push({
       key: isSnapshot ? "id" : this._orderBy.key,
       comp: isSnapshot ? ">" : this._orderBy.direction === "asc" ? '>=' : '=<',
@@ -140,7 +140,7 @@ class Query {
   }
 
   endBefore(value) {
-    const isSnapshot = !!value.ref;
+    const isSnapshot = !!value?.ref;
     this.filters.push({
       key: isSnapshot ? "id" : this._orderBy.key,
       comp: isSnapshot ? ">" : this._orderBy.direction === "asc" ? '<' : '>',
@@ -150,7 +150,7 @@ class Query {
   }
 
   endAt(value) {
-    const isSnapshot = !!value.ref;
+    const isSnapshot = !!value?.ref;
     this.filters.push({
       key: isSnapshot ? "id" : this._orderBy.key,
       comp: isSnapshot ? ">" : this._orderBy.direction === "asc" ? '<=' : '>=',

--- a/mocks/query.js
+++ b/mocks/query.js
@@ -98,6 +98,10 @@ class Query {
         `FakeFirebaseError: Invalid query. Null only supports '==' and '!=' comparisons.`,
       );
     }
+    this._orderBy = this._orderBy.key ?? {
+      key: key,
+      direction: 'asc',
+    };
     this.filters.push({ key, comp, value });
     return result || this;
   }

--- a/mocks/query.js
+++ b/mocks/query.js
@@ -120,22 +120,42 @@ class Query {
   }
 
   startAfter(value) {
-    this.filters.push({ key: this._orderBy.key, comp: this._orderBy.direction === "asc" ? '>' : '<', value });
+    const isSnapshot = !!value.ref;
+    this.filters.push({
+      key: isSnapshot ? "id" : this._orderBy.key,
+      comp: isSnapshot ? ">" : this._orderBy.direction === "asc" ? '>' : '<',
+      value: isSnapshot ? value.id : value,
+    });
     return mockStartAfter(...arguments) || this;
   }
 
   startAt(value) {
-    this.filters.push({ key: this._orderBy.key, comp: this._orderBy.direction === "asc" ? '>=' : '<=', value });
+    const isSnapshot = !!value.ref;
+    this.filters.push({
+      key: isSnapshot ? "id" : this._orderBy.key,
+      comp: isSnapshot ? ">" : this._orderBy.direction === "asc" ? '>=' : '=<',
+      value: isSnapshot ? value.id : value,
+    });
     return mockStartAt(...arguments) || this;
   }
 
   endBefore(value) {
-    this.filters.push({ key: this._orderBy.key, comp: this._orderBy.direction === "asc" ? '<' : '>', value });
+    const isSnapshot = !!value.ref;
+    this.filters.push({
+      key: isSnapshot ? "id" : this._orderBy.key,
+      comp: isSnapshot ? ">" : this._orderBy.direction === "asc" ? '<' : '>',
+      value: isSnapshot ? value.id : value,
+    });
     return mockEndBefore(...arguments) || this;
   }
 
   endAt(value) {
-    this.filters.push({ key: this._orderBy.key, comp: this._orderBy.direction === "asc" ? '<=' : '>=', value });
+    const isSnapshot = !!value.ref;
+    this.filters.push({
+      key: isSnapshot ? "id" : this._orderBy.key,
+      comp: isSnapshot ? ">" : this._orderBy.direction === "asc" ? '<=' : '>=',
+      value: isSnapshot ? value.id : value,
+    });
     return mockEndAt(...arguments) || this;
   }
 

--- a/mocks/query.js
+++ b/mocks/query.js
@@ -122,9 +122,9 @@ class Query {
   startAfter(value) {
     const isSnapshot = !!value?.ref;
     this.filters.push({
-      key: isSnapshot ? "id" : this._orderBy.key,
-      comp: isSnapshot ? ">" : this._orderBy.direction === "asc" ? '>' : '<',
-      value: isSnapshot ? value.id : value,
+      key: isSnapshot ? '_ref.path' : this._orderBy.key,
+      comp: this._orderBy.direction === 'desc' ? '<' : '>',
+      value: isSnapshot ? value.ref.path : value,
     });
     return mockStartAfter(...arguments) || this;
   }
@@ -132,9 +132,9 @@ class Query {
   startAt(value) {
     const isSnapshot = !!value?.ref;
     this.filters.push({
-      key: isSnapshot ? "id" : this._orderBy.key,
-      comp: isSnapshot ? ">" : this._orderBy.direction === "asc" ? '>=' : '=<',
-      value: isSnapshot ? value.id : value,
+      key: isSnapshot ? '_ref.path' : this._orderBy.key,
+      comp: this._orderBy.direction === 'desc' ? '<=' : '>=',
+      value: isSnapshot ? value.ref.path : value,
     });
     return mockStartAt(...arguments) || this;
   }
@@ -142,9 +142,9 @@ class Query {
   endBefore(value) {
     const isSnapshot = !!value?.ref;
     this.filters.push({
-      key: isSnapshot ? "id" : this._orderBy.key,
-      comp: isSnapshot ? ">" : this._orderBy.direction === "asc" ? '<' : '>',
-      value: isSnapshot ? value.id : value,
+      key: isSnapshot ? '_ref.path' : this._orderBy.key,
+      comp: this._orderBy.direction === 'desc' ? '>' : '<',
+      value: isSnapshot ? value.ref.path : value,
     });
     return mockEndBefore(...arguments) || this;
   }
@@ -152,9 +152,9 @@ class Query {
   endAt(value) {
     const isSnapshot = !!value?.ref;
     this.filters.push({
-      key: isSnapshot ? "id" : this._orderBy.key,
-      comp: isSnapshot ? ">" : this._orderBy.direction === "asc" ? '<=' : '>=',
-      value: isSnapshot ? value.id : value,
+      key: isSnapshot ? '_ref.path' : this._orderBy.key,
+      comp: this._orderBy.direction === 'desc' ? '>=' : '<=',
+      value: isSnapshot ? value.ref.path : value,
     });
     return mockEndAt(...arguments) || this;
   }

--- a/mocks/query.js
+++ b/mocks/query.js
@@ -98,7 +98,7 @@ class Query {
         `FakeFirebaseError: Invalid query. Null only supports '==' and '!=' comparisons.`,
       );
     }
-    this._orderBy = this._orderBy.key ? this._orderBy : { key: key, direction: 'asc' };
+    this._orderBy = this._orderBy.key ? this._orderBy : { key, direction: 'asc' };
     this.filters.push({ key, comp, value });
     return result || this;
   }

--- a/mocks/query.js
+++ b/mocks/query.js
@@ -22,6 +22,22 @@ class Query {
     this.isGroupQuery = isGroupQuery;
   }
 
+  #filterForQueryCursor(value, queryName) {
+    const isSnapshot = !!value?.ref;
+    const compMap = {
+      // desc, asc
+      startAfter: ['<', '>'],
+      startAt: ['<=', '>='],
+      endBefore: ['>', '<'],
+      endAt: ['>=', '<='],
+    };
+    return {
+      key: isSnapshot ? '_ref.path' : this._orderBy.key,
+      comp: this._orderBy.direction === 'desc' ? compMap[queryName][0] : compMap[queryName][1],
+      value: isSnapshot ? value.ref.path : value,
+    };
+  }
+
   get() {
     mockGet(...arguments);
     return Promise.resolve(this._get());
@@ -121,42 +137,22 @@ class Query {
   }
 
   startAfter(value) {
-    const isSnapshot = value && value.ref;
-    this.filters.push({
-      key: isSnapshot ? '_ref.path' : this._orderBy.key,
-      comp: this._orderBy.direction === 'desc' ? '<' : '>',
-      value: isSnapshot ? value.ref.path : value,
-    });
+    this.filters.push(this.#filterForQueryCursor(value, 'startAfter'));
     return mockStartAfter(...arguments) || this;
   }
 
   startAt(value) {
-    const isSnapshot = value && value.ref;
-    this.filters.push({
-      key: isSnapshot ? '_ref.path' : this._orderBy.key,
-      comp: this._orderBy.direction === 'desc' ? '<=' : '>=',
-      value: isSnapshot ? value.ref.path : value,
-    });
+    this.filters.push(this.#filterForQueryCursor(value, 'startAt'));
     return mockStartAt(...arguments) || this;
   }
 
   endBefore(value) {
-    const isSnapshot = value && value.ref;
-    this.filters.push({
-      key: isSnapshot ? '_ref.path' : this._orderBy.key,
-      comp: this._orderBy.direction === 'desc' ? '>' : '<',
-      value: isSnapshot ? value.ref.path : value,
-    });
+    this.filters.push(this.#filterForQueryCursor(value, 'endBefore'));
     return mockEndBefore(...arguments) || this;
   }
 
   endAt(value) {
-    const isSnapshot = value && value.ref;
-    this.filters.push({
-      key: isSnapshot ? '_ref.path' : this._orderBy.key,
-      comp: this._orderBy.direction === 'desc' ? '>=' : '<=',
-      value: isSnapshot ? value.ref.path : value,
-    });
+    this.filters.push(this.#filterForQueryCursor(value, 'endAt'));
     return mockEndAt(...arguments) || this;
   }
 

--- a/mocks/query.js
+++ b/mocks/query.js
@@ -98,10 +98,7 @@ class Query {
         `FakeFirebaseError: Invalid query. Null only supports '==' and '!=' comparisons.`,
       );
     }
-    this._orderBy = this._orderBy.key ?? {
-      key: key,
-      direction: 'asc',
-    };
+    this._orderBy = this._orderBy.key ? this._orderBy : { key: key, direction: 'asc' };
     this.filters.push({ key, comp, value });
     return result || this;
   }


### PR DESCRIPTION
# Description

<!-- Write a brief description of the changes introduced by this PR -->
startAfter, startAt, endBefore, endAt에 snapshot을 이용할 수 있도록 수정합니다.
snapshot을 이용할 경우 ref.path 기준으로 가져오도록 하였습니다.

그리고 그냥 limit n개를 쿼리로 가져온 후, n번째 snapshot을 cursor로 이용하면 그 전에는 소팅된 기준이 없어서 값이 꼬이게 됩니다. 
그래서 ref.path (asc)를 default order로 하였습니다(.

그리고 orderBy를 지정한 상태에서도 snapshot을 cursor로 사용할 경우가 있을 것 같아, [orderBy.key, ref.path] 두 값을 stable sort되도록 하였습니다.

## Related issues
https://github.com/frienkly/tangled-timeless-backend/pull/762

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

## How to test
테스트 코드 추가해두었습니다.

<!-- Describe how to test your changes -->