### PR TITLE
[feature] add where for timestamp, timestamp

### DIFF
--- a/__tests__/query.test.js
+++ b/__tests__/query.test.js
@@ -192,6 +192,23 @@ describe('Queries', () => {
     expect(res.docs[1].id).toEqual('ant');
   });
 
+  test.each([['>'], ['>='], ['<'], ['<='], ['=='], ['!=']])(
+    'it can query timestamp values for %s than condition',
+    async comp => {
+      const res1 = await db
+        .collection('animals')
+        .where('createdAt', comp, new Date(1628939129 * 1000))
+        .get();
+
+      const res2 = await db
+        .collection('animals')
+        .where('createdAt', comp, new FakeFirestore.Timestamp(1628939129, 0))
+        .get();
+
+      expect(res1.docs.map(doc => doc.id)).toEqual(res2.docs.map(doc => doc.id));
+    },
+  );
+
   test('it can query multiple documents', async () => {
     expect.assertions(9);
     const animals = await db.collection('animals').where('type', '==', 'mammal').get();

--- a/mocks/helpers/buildQuerySnapShot.js
+++ b/mocks/helpers/buildQuerySnapShot.js
@@ -152,6 +152,19 @@ function _shouldCompareNumerically(a, b) {
   return typeof a === 'number' && typeof b === 'number';
 }
 
+function _shouldCompareTimestampWithTimestamp(a, b) {
+  //We check whether toMillis method exists to support both Timestamp mock and Firestore Timestamp object
+  //B is expected to be Date, not Timestamp, just like Firestore does
+  return (
+    typeof a === 'object' &&
+    a !== null &&
+    typeof a.toMillis === 'function' &&
+    typeof b === 'object' &&
+    b !== null &&
+    typeof b.toMillis === 'function'
+  );
+}
+
 function _shouldCompareTimestamp(a, b) {
   //We check whether toMillis method exists to support both Timestamp mock and Firestore Timestamp object
   //B is expected to be Date, not Timestamp, just like Firestore does
@@ -172,6 +185,9 @@ function _recordsLessThanValue(records, key, value) {
     if (_shouldCompareNumerically(v, value)) {
       return v < value;
     }
+    if (_shouldCompareTimestampWithTimestamp(v, value)) {
+      return v.toMillis() < value.toMillis;
+    }
     if (_shouldCompareTimestamp(v, value)) {
       return v.toMillis() < value;
     }
@@ -191,6 +207,9 @@ function _recordsLessThanOrEqualToValue(records, key, value) {
     if (_shouldCompareNumerically(v, value)) {
       return v <= value;
     }
+    if (_shouldCompareTimestampWithTimestamp(v, value)) {
+      return v.toMillis() <= value.toMillis;
+    }
     if (_shouldCompareTimestamp(v, value)) {
       return v.toMillis() <= value;
     }
@@ -207,6 +226,9 @@ function _recordsLessThanOrEqualToValue(records, key, value) {
 function _recordsEqualToValue(records, key, value) {
   return _recordsWithKey(records, key).filter(record => {
     const v = _getValueByKey(record, key);
+    if (_shouldCompareTimestampWithTimestamp(v, value)) {
+      return v.toMillis() === value.toMillis;
+    }
     if (_shouldCompareTimestamp(v, value)) {
       //NOTE: for equality, we must compare numbers!
       return v.toMillis() === value.getTime();
@@ -224,6 +246,9 @@ function _recordsEqualToValue(records, key, value) {
 function _recordsNotEqualToValue(records, key, value) {
   return _recordsWithKey(records, key).filter(record => {
     const v = _getValueByKey(record, key);
+    if (_shouldCompareTimestampWithTimestamp(v, value)) {
+      return v.toMillis() !== value.toMillis;
+    }
     if (_shouldCompareTimestamp(v, value)) {
       //NOTE: for equality, we must compare numbers!
       return v.toMillis() !== value.getTime();
@@ -244,6 +269,9 @@ function _recordsGreaterThanOrEqualToValue(records, key, value) {
     if (_shouldCompareNumerically(v, value)) {
       return v >= value;
     }
+    if (_shouldCompareTimestampWithTimestamp(v, value)) {
+      return v.toMillis() >= value.toMillis;
+    }
     if (_shouldCompareTimestamp(v, value)) {
       return v.toMillis() >= value;
     }
@@ -262,6 +290,9 @@ function _recordsGreaterThanValue(records, key, value) {
     const v = _getValueByKey(record, key);
     if (_shouldCompareNumerically(v, value)) {
       return v > value;
+    }
+    if (_shouldCompareTimestampWithTimestamp(v, value)) {
+      return v.toMillis() > value.toMillis;
     }
     if (_shouldCompareTimestamp(v, value)) {
       return v.toMillis() > value;

--- a/mocks/helpers/buildQuerySnapShot.js
+++ b/mocks/helpers/buildQuerySnapShot.js
@@ -186,7 +186,7 @@ function _recordsLessThanValue(records, key, value) {
       return v < value;
     }
     if (_shouldCompareTimestampWithTimestamp(v, value)) {
-      return v.toMillis() < value.toMillis;
+      return v.toMillis() < value.toMillis();
     }
     if (_shouldCompareTimestamp(v, value)) {
       return v.toMillis() < value;
@@ -208,7 +208,7 @@ function _recordsLessThanOrEqualToValue(records, key, value) {
       return v <= value;
     }
     if (_shouldCompareTimestampWithTimestamp(v, value)) {
-      return v.toMillis() <= value.toMillis;
+      return v.toMillis() <= value.toMillis();
     }
     if (_shouldCompareTimestamp(v, value)) {
       return v.toMillis() <= value;
@@ -227,7 +227,7 @@ function _recordsEqualToValue(records, key, value) {
   return _recordsWithKey(records, key).filter(record => {
     const v = _getValueByKey(record, key);
     if (_shouldCompareTimestampWithTimestamp(v, value)) {
-      return v.toMillis() === value.toMillis;
+      return v.toMillis() === value.toMillis();
     }
     if (_shouldCompareTimestamp(v, value)) {
       //NOTE: for equality, we must compare numbers!
@@ -247,7 +247,7 @@ function _recordsNotEqualToValue(records, key, value) {
   return _recordsWithKey(records, key).filter(record => {
     const v = _getValueByKey(record, key);
     if (_shouldCompareTimestampWithTimestamp(v, value)) {
-      return v.toMillis() !== value.toMillis;
+      return v.toMillis() !== value.toMillis();
     }
     if (_shouldCompareTimestamp(v, value)) {
       //NOTE: for equality, we must compare numbers!
@@ -270,7 +270,7 @@ function _recordsGreaterThanOrEqualToValue(records, key, value) {
       return v >= value;
     }
     if (_shouldCompareTimestampWithTimestamp(v, value)) {
-      return v.toMillis() >= value.toMillis;
+      return v.toMillis() >= value.toMillis();
     }
     if (_shouldCompareTimestamp(v, value)) {
       return v.toMillis() >= value;
@@ -292,7 +292,7 @@ function _recordsGreaterThanValue(records, key, value) {
       return v > value;
     }
     if (_shouldCompareTimestampWithTimestamp(v, value)) {
-      return v.toMillis() > value.toMillis;
+      return v.toMillis() > value.toMillis();
     }
     if (_shouldCompareTimestamp(v, value)) {
       return v.toMillis() > value;

--- a/mocks/helpers/buildQuerySnapShot.js
+++ b/mocks/helpers/buildQuerySnapShot.js
@@ -154,7 +154,7 @@ function _shouldCompareNumerically(a, b) {
 
 function _shouldCompareTimestampWithTimestamp(a, b) {
   //We check whether toMillis method exists to support both Timestamp mock and Firestore Timestamp object
-  //B is expected to be Date, not Timestamp, just like Firestore does
+  //B is expected to be Timestamp, just like Firestore does
   return (
     typeof a === 'object' &&
     a !== null &&
@@ -167,7 +167,7 @@ function _shouldCompareTimestampWithTimestamp(a, b) {
 
 function _shouldCompareTimestamp(a, b) {
   //We check whether toMillis method exists to support both Timestamp mock and Firestore Timestamp object
-  //B is expected to be Date, not Timestamp, just like Firestore does
+  //B is expected to be Date, just like Firestore does
   return (
     typeof a === 'object' && a !== null && typeof a.toMillis === 'function' && b instanceof Date
   );


### PR DESCRIPTION
타임스탬프 값간의 비교 로직 추가합니다.

## Related issues
https://github.com/frienkly/tangled-timeless-backend/pull/924 에서 milliseconds 값을 getByQueryList의 where절 value로 Timestamp.fromMillis()해서 쿼리를 날리는데, 이걸 테스트를 제대로 하기 위해 타임스탬프로 where절이 제대로 동작하도록 수정합니다.

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

## How to test
수정해서 unittest 실행해보니 현재의 모든 테스트 케이스 정상 동작하는것 확인했습니다.
unittest 추가해두었습니다.
<!-- Describe how to test your changes -->
